### PR TITLE
include listener and behavior-mouse-setting source, if any device tree node found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(src/drivers)
 
-target_sources_ifdef(CONFIG_ZMK_INPUT_MOUSE_PS2 app PRIVATE src/mouse/input_listener_ps2.c)
-target_sources_ifdef(CONFIG_ZMK_INPUT_MOUSE_PS2 app PRIVATE src/behaviors/behavior_mouse_setting.c)
+target_sources_ifdef(CONFIG_ZMK_INPUT_LISTENER_PS2 app PRIVATE src/mouse/input_listener_ps2.c)
+target_sources_ifdef(CONFIG_ZMK_BEHAVIOR_MOUSE_SETTING app PRIVATE src/behaviors/behavior_mouse_setting.c)
 
 zephyr_include_directories(include)

--- a/Kconfig
+++ b/Kconfig
@@ -2,3 +2,13 @@
 # SPDX-License-Identifier: MIT
 
 rsource "src/drivers/Kconfig"
+
+DT_COMPAT_ZMK_INPUT_LISTENER_PS2 := zmk,input-listener-ps2
+config ZMK_INPUT_LISTENER_PS2
+		bool
+		default $(dt_compat_enabled,$(DT_COMPAT_ZMK_INPUT_LISTENER_PS2))
+
+DT_COMPAT_ZMK_BEHAVIOR_MOUSE_SETTING := zmk,behavior-mouse-setting
+config ZMK_BEHAVIOR_MOUSE_SETTING
+		bool
+		default $(dt_compat_enabled,$(DT_COMPAT_ZMK_BEHAVIOR_MOUSE_SETTING))


### PR DESCRIPTION
As titled that allow `zmk,input-mouse-ps2` device runs on split-peripheral with [zmk-split-peripheral-input-relay](https://github.com/badjeff/zmk-split-peripheral-input-relay)