### PR TITLE
disable config ZMK_INPUT_MOUSE_PS2 depends on split role

### DIFF
--- a/src/drivers/input/Kconfig
+++ b/src/drivers/input/Kconfig
@@ -16,6 +16,12 @@ config ZMK_INPUT_MOUSE_PS2_ENABLE_PS2_RESEND_CALLBACK
 
 if ZMK_INPUT_MOUSE_PS2
 
+config ZMK_INPUT_MOUSE_PS2_POWER_ON_RESET_TIME
+    int "The POR shall be timed to occur 600 ms ± 20 % from the time power is applied to the TrackPoint controller."
+    default 600
+    help
+      Refer to IBM TrackPoint System Version 4.0 Engineering Specification - Section 2.1
+
 config ZMK_INPUT_MOUSE_PS2_ENABLE_UROB_COMPAT
     bool "Makes the driver compatible with urob's zmk fork. His fork has commits that change the default zmk function definitions. This option adopts the code to make it compatible with his changes. Only enable it if you are using his fork or it will fail to compile."
 	default n

--- a/src/drivers/input/Kconfig
+++ b/src/drivers/input/Kconfig
@@ -6,7 +6,7 @@ DT_COMPAT_ZMK_INPUT_PS2_MOUSE := zmk,input-mouse-ps2
 config ZMK_INPUT_MOUSE_PS2
 	bool
 	default $(dt_compat_enabled,$(DT_COMPAT_ZMK_INPUT_PS2_MOUSE))
-    depends on (!ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL)
+    # depends on (!ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL)
 	select ZMK_MOUSE
     select PS2
 

--- a/src/drivers/input/Kconfig
+++ b/src/drivers/input/Kconfig
@@ -24,4 +24,11 @@ config ZMK_INPUT_MOUSE_PS2_ENABLE_ERROR_MITIGATION
     bool "Tries to mitigate transmission errors. Only useful when using a PS2 driver that is prone to miscommunication like the GPIO bitbanging driver."
 	default n
 
+config ZMK_INPUT_MOUSE_PS2_REPORT_INTERVAL_MIN
+    int "Minimum report rate. Use to avoid bluetooth queue overflow."
+    default 0
+    help
+      Default minimum report interval in milliseconds.
+      Slow down input reporting for hid queue over the air.
+
 endif # ZMK_INPUT_MOUSE_PS2

--- a/src/drivers/input/input_mouse_ps2.c
+++ b/src/drivers/input/input_mouse_ps2.c
@@ -43,7 +43,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 // Specification`...
 // "The POR shall be timed to occur 600 ms ± 20 % from the time power is
 //  applied to the TrackPoint controller."
-#define MOUSE_PS2_POWER_ON_RESET_TIME K_MSEC(600)
+#define MOUSE_PS2_POWER_ON_RESET_TIME K_MSEC(CONFIG_ZMK_INPUT_MOUSE_PS2_POWER_ON_RESET_TIME)
 
 // Common PS/2 Mouse commands
 #define MOUSE_PS2_CMD_GET_DEVICE_ID "\xf2"

--- a/src/drivers/input/input_mouse_ps2.c
+++ b/src/drivers/input/input_mouse_ps2.c
@@ -1996,7 +1996,7 @@ DT_INST_FOREACH_STATUS_OKAY(PS2_MOUSE_CALLBACK_DEFINE)
         .tp_y_invert = DT_INST_PROP_OR(n, tp_y_invert, false),                                \
         .tp_xy_swap = DT_INST_PROP_OR(n, tp_xy_swap, false),                                  \
     };                                                                                        \
-    DEVICE_DT_INST_DEFINE(0, &zmk_mouse_ps2_init, NULL, &data##n, &config##n,                 \
+    DEVICE_DT_INST_DEFINE(n, &zmk_mouse_ps2_init, NULL, &data##n, &config##n,                 \
                         POST_KERNEL, ZMK_MOUSE_PS2_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(ZMK_PS2_MOUSE_DEFINE)

--- a/src/drivers/input/input_mouse_ps2.c
+++ b/src/drivers/input/input_mouse_ps2.c
@@ -192,7 +192,7 @@ struct zmk_mouse_ps2_data {
     const struct device *dev;
     struct gpio_dt_spec rst_gpio; /* GPIO used for Power-On-Reset line */
 
-    K_THREAD_STACK_MEMBER(thread_stack, MOUSE_PS2_THREAD_STACK_SIZE);
+    K_KERNEL_STACK_MEMBER(thread_stack, MOUSE_PS2_THREAD_STACK_SIZE);
     struct k_thread thread;
 
     zmk_mouse_ps2_packet_mode packet_mode;

--- a/src/drivers/input/input_mouse_ps2.c
+++ b/src/drivers/input/input_mouse_ps2.c
@@ -1974,13 +1974,13 @@ DT_INST_FOREACH_STATUS_OKAY(PS2_MOUSE_CALLBACK_DEFINE)
     };                                                                                        \
     static const struct zmk_mouse_ps2_config config##n = {                                    \
         .ps2_device = DEVICE_DT_GET(DT_INST_PHANDLE(n, ps2_device)),                          \
-        .has_rst_gpio = DT_INST_NODE_HAS_PROP(n, rst_gpio),                                   \
+        .has_rst_gpio = DT_INST_NODE_HAS_PROP(n, rst_gpios),                                  \
         .rst_gpio = COND_CODE_1(                                                              \
-            DT_INST_NODE_HAS_PROP(n, rst_gpio),                                               \
+            DT_INST_NODE_HAS_PROP(n, rst_gpios),                                              \
             (GPIO_DT_SPEC_INST_GET(n, rst_gpios)),                                            \
             ({ .port = NULL, .pin = 0, .dt_flags = 0, })),                                    \
         .rst_gpio_port_num = COND_CODE_1(                                                     \
-            DT_INST_NODE_HAS_PROP(n, rst_gpio),                                               \
+            DT_INST_NODE_HAS_PROP(n, rst_gpios),                                              \
             (DT_PROP(DT_INST_PHANDLE(n, rst_gpios), port)),                                   \
             (0)),                                                                             \
         .scroll_mode = DT_INST_PROP_OR(n, scroll_mode, false),                                \

--- a/src/drivers/ps2/ps2_uart.c
+++ b/src/drivers/ps2/ps2_uart.c
@@ -186,33 +186,9 @@ struct ps2_uart_data {
     struct k_work_delayable write_scl_timout;
 
     struct k_work resend_cmd_work;
-};
 
-static const struct ps2_uart_config ps2_uart_config = {
-    .uart_dev = DEVICE_DT_GET(DT_INST_BUS(0)),
-    .scl_gpio = GPIO_DT_SPEC_INST_GET(0, scl_gpios),
-    .sda_gpio = GPIO_DT_SPEC_INST_GET(0, sda_gpios),
-    .pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_INST_BUS(0)),
-
-    .scl_gpio_port_num = DT_PROP(DT_INST_PHANDLE(0, scl_gpios), port),
-    .sda_gpio_port_num = DT_PROP(DT_INST_PHANDLE(0, sda_gpios), port),
-};
-
-static struct ps2_uart_data ps2_uart_data = {
-    .callback_byte = 0x0,
-    .callback_isr = NULL,
-
-#if IS_ENABLED(CONFIG_PS2_UART_ENABLE_PS2_RESEND_CALLBACK)
-    .resend_callback_isr = NULL,
-#endif /* IS_ENABLED(CONFIG_PS2_UART_ENABLE_PS2_RESEND_CALLBACK) */
-
-    .callback_enabled = false,
-
-    .cur_write_status = PS2_UART_WRITE_STATUS_INACTIVE,
-    .cur_write_byte = 0x0,
-    .cur_write_pos = 0,
-    .write_awaits_resp = false,
-    .write_awaits_resp_byte = 0x0,
+    void *scl_rupt_async;
+    void *scl_rupt_blocking;
 };
 
 K_THREAD_STACK_DEFINE(ps2_uart_work_queue_stack_area, PS2_UART_WORK_QUEUE_STACK_SIZE);
@@ -225,7 +201,7 @@ static struct k_work_q ps2_uart_work_queue_cb;
  * Function Definitions
  */
 
-int ps2_uart_write_byte(uint8_t byte);
+int ps2_uart_write_byte(const struct device *dev, uint8_t byte);
 
 /*
  * Helpers functions
@@ -233,35 +209,35 @@ int ps2_uart_write_byte(uint8_t byte);
 
 #define PS2_UART_GET_BIT(data, bit_pos) ((data >> bit_pos) & 0x1)
 
-int ps2_uart_get_scl() {
-    const struct ps2_uart_config *config = &ps2_uart_config;
+int ps2_uart_get_scl(const struct device *dev) {
+    const struct ps2_uart_config *config = dev->config;
     int rc = gpio_pin_get_dt(&config->scl_gpio);
 
     return rc;
 }
 
-int ps2_uart_get_sda() {
-    const struct ps2_uart_config *config = &ps2_uart_config;
+int ps2_uart_get_sda(const struct device *dev) {
+    const struct ps2_uart_config *config = dev->config;
     int rc = gpio_pin_get_dt(&config->sda_gpio);
 
     return rc;
 }
 
-void ps2_uart_set_scl(int state) {
-    const struct ps2_uart_config *config = &ps2_uart_config;
+void ps2_uart_set_scl(const struct device *dev, int state) {
+    const struct ps2_uart_config *config = dev->config;
 
     gpio_pin_set_dt(&config->scl_gpio, state);
 }
 
-void ps2_uart_set_sda(int state) {
-    const struct ps2_uart_config *config = &ps2_uart_config;
+void ps2_uart_set_sda(const struct device *dev, int state) {
+    const struct ps2_uart_config *config = dev->config;
 
     // LOG_INF("Seting sda to %d", state);
     gpio_pin_set_dt(&config->sda_gpio, state);
 }
 
-int ps2_uart_configure_pin_scl(gpio_flags_t flags, char *descr) {
-    struct ps2_uart_config *config = (struct ps2_uart_config *)&ps2_uart_config;
+int ps2_uart_configure_pin_scl(const struct device *dev, gpio_flags_t flags, char *descr) {
+    const struct ps2_uart_config *config = dev->config;
     int err;
 
     err = gpio_pin_configure_dt(&config->scl_gpio, flags);
@@ -272,14 +248,16 @@ int ps2_uart_configure_pin_scl(gpio_flags_t flags, char *descr) {
     return err;
 }
 
-int ps2_uart_configure_pin_scl_input() { return ps2_uart_configure_pin_scl((GPIO_INPUT), "input"); }
-
-int ps2_uart_configure_pin_scl_output() {
-    return ps2_uart_configure_pin_scl((GPIO_OUTPUT_HIGH), "output");
+int ps2_uart_configure_pin_scl_input(const struct device *dev) {
+    return ps2_uart_configure_pin_scl(dev, (GPIO_INPUT), "input");
 }
 
-int ps2_uart_configure_pin_sda(gpio_flags_t flags, char *descr) {
-    struct ps2_uart_config *config = (struct ps2_uart_config *)&ps2_uart_config;
+int ps2_uart_configure_pin_scl_output(const struct device *dev) {
+    return ps2_uart_configure_pin_scl(dev, (GPIO_OUTPUT_HIGH), "output");
+}
+
+int ps2_uart_configure_pin_sda(const struct device *dev, gpio_flags_t flags, char *descr) {
+    const struct ps2_uart_config *config = dev->config;
     int err;
 
     err = gpio_pin_configure_dt(&config->sda_gpio, flags);
@@ -290,14 +268,16 @@ int ps2_uart_configure_pin_sda(gpio_flags_t flags, char *descr) {
     return err;
 }
 
-int ps2_uart_configure_pin_sda_input() { return ps2_uart_configure_pin_sda((GPIO_INPUT), "input"); }
-
-int ps2_uart_configure_pin_sda_output() {
-    return ps2_uart_configure_pin_sda((GPIO_OUTPUT_HIGH), "output");
+int ps2_uart_configure_pin_sda_input(const struct device *dev) {
+    return ps2_uart_configure_pin_sda(dev, (GPIO_INPUT), "input");
 }
 
-int ps2_uart_set_scl_callback_enabled(bool enabled) {
-    struct ps2_uart_config *config = (struct ps2_uart_config *)&ps2_uart_config;
+int ps2_uart_configure_pin_sda_output(const struct device *dev) {
+    return ps2_uart_configure_pin_sda(dev, (GPIO_OUTPUT_HIGH), "output");
+}
+
+int ps2_uart_set_scl_callback_enabled(const struct device *dev, bool enabled) {
+    const struct ps2_uart_config *config = dev->config;
     int err;
 
     // LOG_INF("Setting ps2_uart_set_scl_callback_enabled: %d", enabled);
@@ -323,8 +303,8 @@ int ps2_uart_set_scl_callback_enabled(bool enabled) {
     return err;
 }
 
-static int ps2_uart_set_mode_read() {
-    const struct ps2_uart_config *config = &ps2_uart_config;
+static int ps2_uart_set_mode_read(const struct device *dev) {
+    const struct ps2_uart_config *config = dev->config;
     int err;
 
     // Set the SDA pin for the uart device
@@ -335,7 +315,7 @@ static int ps2_uart_set_mode_read() {
     }
 
     // Make sure SCL interrupt is disabled
-    ps2_uart_set_scl_callback_enabled(false);
+    ps2_uart_set_scl_callback_enabled(dev, false);
 
     // Enable UART interrupt
     uart_irq_rx_enable(config->uart_dev);
@@ -343,8 +323,8 @@ static int ps2_uart_set_mode_read() {
     return err;
 }
 
-static int ps2_uart_set_mode_write() {
-    const struct ps2_uart_config *config = &ps2_uart_config;
+static int ps2_uart_set_mode_write(const struct device *dev) {
+    const struct ps2_uart_config *config = dev->config;
     int err;
 
     // Set pincntrl with unused pins so that we can control the pins
@@ -361,9 +341,9 @@ static int ps2_uart_set_mode_write() {
     uart_irq_rx_disable(config->uart_dev);
 
     // Configure data and clock lines for output
-    ps2_uart_set_scl_callback_enabled(false);
-    ps2_uart_configure_pin_scl_output();
-    ps2_uart_configure_pin_sda_output();
+    ps2_uart_set_scl_callback_enabled(dev, false);
+    ps2_uart_configure_pin_scl_output(dev);
+    ps2_uart_configure_pin_sda_output(dev);
 
     return err;
 }
@@ -388,8 +368,8 @@ bool ps2_uart_get_byte_parity(uint8_t byte) {
     return !byte_parity;
 }
 
-uint8_t ps2_uart_data_queue_get_next(uint8_t *dst_byte, k_timeout_t timeout) {
-    struct ps2_uart_data *data = &ps2_uart_data;
+uint8_t ps2_uart_data_queue_get_next(const struct device *dev, uint8_t *dst_byte, k_timeout_t timeout) {
+    struct ps2_uart_data *data = dev->data;
     struct ps2_uart_data_queue_item queue_data;
     int ret;
 
@@ -404,14 +384,14 @@ uint8_t ps2_uart_data_queue_get_next(uint8_t *dst_byte, k_timeout_t timeout) {
     return 0;
 }
 
-void ps2_uart_data_queue_empty() {
-    struct ps2_uart_data *data = &ps2_uart_data;
+void ps2_uart_data_queue_empty(const struct device *dev) {
+    struct ps2_uart_data *data = dev->data;
 
     k_msgq_purge(&data->data_queue);
 }
 
-void ps2_uart_data_queue_add(uint8_t byte) {
-    struct ps2_uart_data *data = &ps2_uart_data;
+void ps2_uart_data_queue_add(const struct device *dev, uint8_t byte) {
+    struct ps2_uart_data *data = dev->data;
 
     int ret;
 
@@ -428,7 +408,7 @@ void ps2_uart_data_queue_add(uint8_t byte) {
             LOG_WRN("Data queue full. Removing oldest item.");
 
             uint8_t tmp_byte;
-            ps2_uart_data_queue_get_next(&tmp_byte, K_NO_WAIT);
+            ps2_uart_data_queue_get_next(dev, &tmp_byte, K_NO_WAIT);
         }
     }
 
@@ -439,9 +419,13 @@ void ps2_uart_data_queue_add(uint8_t byte) {
 
 void ps2_uart_send_cmd_resend_worker(struct k_work *item) {
 
-#if IS_ENABLED(CONFIG_PS2_UART_ENABLE_PS2_RESEND_CALLBACK)
+    // struct k_work_delayable *work_delayable = (struct k_work_delayable *)work;
+    struct ps2_uart_data *data = CONTAINER_OF(item,
+                                              struct ps2_uart_data,
+                                              resend_cmd_work);
+    const struct device *dev = data->dev;
 
-    struct ps2_uart_data *data = &ps2_uart_data;
+#if IS_ENABLED(CONFIG_PS2_UART_ENABLE_PS2_RESEND_CALLBACK)
 
     // Notify the PS/2 device driver that we are requesting a resend.
     // PS/2 devices don't just resend the last byte that was sent, but the
@@ -455,11 +439,11 @@ void ps2_uart_send_cmd_resend_worker(struct k_work *item) {
 
     uint8_t cmd = 0xfe;
     // LOG_DBG("Requesting resend of data with command: 0x%x", cmd);
-    ps2_uart_write_byte(cmd);
+    ps2_uart_write_byte(dev, cmd);
 }
 
-void ps2_uart_send_cmd_resend() {
-    struct ps2_uart_data *data = &ps2_uart_data;
+void ps2_uart_send_cmd_resend(const struct device *dev) {
+    struct ps2_uart_data *data = dev->data;
 
     if (k_is_in_isr()) {
 
@@ -469,7 +453,8 @@ void ps2_uart_send_cmd_resend() {
         // inhibition delay worker will never be called.
         k_work_submit_to_queue(&ps2_uart_work_queue_cb, &data->resend_cmd_work);
     } else {
-        ps2_uart_send_cmd_resend_worker(NULL);
+        // ps2_uart_send_cmd_resend_worker(NULL);
+        k_work_submit_to_queue(&ps2_uart_work_queue_cb, &data->resend_cmd_work);
     }
 }
 
@@ -520,12 +505,13 @@ int ps2_uart_get_pinctrl_port_pin(const struct pinctrl_dev_config *pcfg, uint8_t
  * Reading PS2 data
  */
 static void ps2_uart_interrupt_handler(const struct device *uart_dev, void *user_data);
-void ps2_uart_read_interrupt_handler();
+void ps2_uart_read_interrupt_handler(const struct device *uart_dev, void *user_data);
 static int ps2_uart_read_err_check(const struct device *dev);
-void ps2_uart_read_process_received_byte(uint8_t byte);
+void ps2_uart_read_process_received_byte(const struct device *dev, uint8_t byte);
 const char *ps2_uart_read_get_error_str(int err);
 
 static void ps2_uart_interrupt_handler(const struct device *uart_dev, void *user_data) {
+    // const struct device* dev = (const struct device*)user_data;
     int err;
 
     err = uart_irq_update(uart_dev);
@@ -540,6 +526,7 @@ static void ps2_uart_interrupt_handler(const struct device *uart_dev, void *user
 }
 
 void ps2_uart_read_interrupt_handler(const struct device *uart_dev, void *user_data) {
+    const struct device* dev = (const struct device*)user_data;
     uint8_t byte;
 
     int byte_len = uart_fifo_read(uart_dev, &byte, 1);
@@ -548,7 +535,7 @@ void ps2_uart_read_interrupt_handler(const struct device *uart_dev, void *user_d
         return;
     }
 
-    ps2_uart_read_process_received_byte(byte);
+    ps2_uart_read_process_received_byte(dev, byte);
 }
 
 static int ps2_uart_read_err_check(const struct device *dev) {
@@ -576,9 +563,9 @@ static int ps2_uart_read_err_check(const struct device *dev) {
     return err;
 }
 
-void ps2_uart_read_process_received_byte(uint8_t byte) {
-    struct ps2_uart_data *data = &ps2_uart_data;
-    const struct ps2_uart_config *config = &ps2_uart_config;
+void ps2_uart_read_process_received_byte(const struct device *dev, uint8_t byte) {
+    struct ps2_uart_data *data = dev->data;
+    const struct ps2_uart_config *config = dev->config;
 
     int err;
 
@@ -626,7 +613,7 @@ void ps2_uart_read_process_received_byte(uint8_t byte) {
         data->callback_byte = byte;
         k_work_submit_to_queue(&ps2_uart_work_queue_cb, &data->callback_work);
     } else {
-        ps2_uart_data_queue_add(byte);
+        ps2_uart_data_queue_add(dev, byte);
     }
 }
 
@@ -648,7 +635,12 @@ const char *ps2_uart_read_get_error_str(int err) {
 }
 
 void ps2_uart_read_callback_work_handler(struct k_work *work) {
-    struct ps2_uart_data *data = &ps2_uart_data;
+
+    // struct k_work_delayable *work_delayable = (struct k_work_delayable *)item;
+    struct ps2_uart_data *data = CONTAINER_OF(work,
+                                              struct ps2_uart_data,
+                                              callback_work);
+    // const struct device *dev = data->dev;
 
     data->callback_isr(data->dev, data->callback_byte);
     data->callback_byte = 0x0;
@@ -658,13 +650,13 @@ void ps2_uart_read_callback_work_handler(struct k_work *work) {
  * Writing PS2 data
  */
 
-int ps2_uart_write_byte_await_response(uint8_t byte);
-int ps2_uart_write_byte_blocking(uint8_t byte);
-int ps2_uart_write_byte_start(uint8_t byte);
+int ps2_uart_write_byte_await_response(const struct device *dev, uint8_t byte);
+int ps2_uart_write_byte_blocking(const struct device *dev, uint8_t byte);
+int ps2_uart_write_byte_start(const struct device *dev, uint8_t byte);
 void ps2_uart_write_scl_interrupt_handler(const struct device *dev, struct gpio_callback *cb,
                                           uint32_t pins);
 void ps2_uart_write_scl_timeout(struct k_work *item);
-void ps2_uart_write_finish(bool successful, char *descr);
+void ps2_uart_write_finish(const struct device *dev, bool successful, char *descr);
 
 // Returned when there was an error writing to the PS2 device, such
 // as not getting a clock from the device or receiving an invalid
@@ -691,19 +683,19 @@ void ps2_uart_write_finish(bool successful, char *descr);
 
 K_MUTEX_DEFINE(ps2_uart_write_mutex);
 
-int ps2_uart_write_byte_debug(uint8_t byte) {
+int ps2_uart_write_byte_debug(const struct device *dev, uint8_t byte) {
     int err;
 
     LOG_WRN("DEBUG WRITE STARTED for byte 0x%x", byte);
 
     LOG_WRN("Setting Write mode");
-    err = ps2_uart_set_mode_write();
+    err = ps2_uart_set_mode_write(dev);
     if (err != 0) {
         LOG_ERR("Could not configure driver for write mode: %d", err);
         return err;
     }
     // k_sleep(K_MSEC(1000));
-    // err = ps2_uart_set_mode_write();
+    // err = ps2_uart_set_mode_write(dev);
     // if (err != 0) {
     //  LOG_ERR("Could not configure driver for write mode: %d", err);
     //  return err;
@@ -712,50 +704,50 @@ int ps2_uart_write_byte_debug(uint8_t byte) {
 
     // Inhibit the line by setting clock low and data high for 100us
     LOG_INF("Setting low");
-    ps2_uart_set_scl(0);
-    ps2_uart_set_sda(0);
+    ps2_uart_set_scl(dev, 0);
+    ps2_uart_set_sda(dev, 0);
     k_sleep(K_MSEC(100));
 
     LOG_INF("Setting high");
-    ps2_uart_set_scl(1);
-    ps2_uart_set_sda(1);
+    ps2_uart_set_scl(dev, 1);
+    ps2_uart_set_sda(dev, 1);
     k_sleep(K_MSEC(100));
 
     LOG_INF("Setting low");
-    ps2_uart_set_scl(0);
-    ps2_uart_set_sda(0);
+    ps2_uart_set_scl(dev, 0);
+    ps2_uart_set_sda(dev, 0);
     k_sleep(K_MSEC(100));
 
     LOG_INF("Setting high");
-    ps2_uart_set_scl(1);
-    ps2_uart_set_sda(1);
+    ps2_uart_set_scl(dev, 1);
+    ps2_uart_set_sda(dev, 1);
     k_sleep(K_MSEC(100));
 
     LOG_INF("Setting low");
-    ps2_uart_set_scl(0);
-    ps2_uart_set_sda(0);
+    ps2_uart_set_scl(dev, 0);
+    ps2_uart_set_sda(dev, 0);
     k_sleep(K_MSEC(100));
 
     LOG_INF("Setting high");
-    ps2_uart_set_scl(1);
-    ps2_uart_set_sda(1);
+    ps2_uart_set_scl(dev, 1);
+    ps2_uart_set_sda(dev, 1);
     k_sleep(K_MSEC(100));
 
     LOG_INF("Setting low");
-    ps2_uart_set_scl(0);
-    ps2_uart_set_sda(0);
+    ps2_uart_set_scl(dev, 0);
+    ps2_uart_set_sda(dev, 0);
     k_sleep(K_MSEC(100));
 
     LOG_WRN("Enabling interrupt callback");
-    ps2_uart_set_scl_callback_enabled(true);
+    ps2_uart_set_scl_callback_enabled(dev, true);
 
     LOG_WRN("Setting SCL input");
-    ps2_uart_configure_pin_scl_input();
+    ps2_uart_configure_pin_scl_input(dev);
 
     k_sleep(K_MSEC(300));
 
     LOG_WRN("Switching back to mode read");
-    err = ps2_uart_set_mode_read();
+    err = ps2_uart_set_mode_read(dev);
     if (err != 0) {
         LOG_ERR("Could not configure driver for write mode: %d", err);
         return err;
@@ -766,7 +758,7 @@ int ps2_uart_write_byte_debug(uint8_t byte) {
     return -1;
 }
 
-int ps2_uart_write_byte(uint8_t byte) {
+int ps2_uart_write_byte(const struct device *dev, uint8_t byte) {
     int err;
 
     LOG_DBG("\n");
@@ -779,7 +771,7 @@ int ps2_uart_write_byte(uint8_t byte) {
             LOG_WRN("Attempting write re-try #%d of %d...", i + 1, PS2_UART_WRITE_MAX_RETRY);
         }
 
-        err = ps2_uart_write_byte_await_response(byte);
+        err = ps2_uart_write_byte_await_response(dev, byte);
 
         if (err == 0) {
             if (i > 0) {
@@ -806,11 +798,11 @@ int ps2_uart_write_byte(uint8_t byte) {
 // Returns success if the response is 0xfa (ack) or any value except of
 // 0xfe.
 // 0xfe, 0xfc and 0xfa are not passed on to the read data queue or callback.
-int ps2_uart_write_byte_await_response(uint8_t byte) {
-    struct ps2_uart_data *data = &ps2_uart_data;
+int ps2_uart_write_byte_await_response(const struct device *dev, uint8_t byte) {
+    struct ps2_uart_data *data = dev->data;
     int err;
 
-    err = ps2_uart_write_byte_blocking(byte);
+    err = ps2_uart_write_byte_blocking(dev, byte);
     if (err) {
         return err;
     }
@@ -852,13 +844,13 @@ int ps2_uart_write_byte_await_response(uint8_t byte) {
     return 0;
 }
 
-int ps2_uart_write_byte_blocking(uint8_t byte) {
-    struct ps2_uart_data *data = &ps2_uart_data;
+int ps2_uart_write_byte_blocking(const struct device *dev, uint8_t byte) {
+    struct ps2_uart_data *data = dev->data;
     int err;
 
     // LOG_DBG("ps2_uart_write_byte_blocking called with byte=0x%x", byte);
 
-    err = ps2_uart_write_byte_start(byte);
+    err = ps2_uart_write_byte_start(dev, byte);
     if (err) {
         LOG_ERR("Could not initiate writing of byte.");
         return PS2_UART_E_WRITE_TRANSMIT;
@@ -896,8 +888,8 @@ int ps2_uart_write_byte_blocking(uint8_t byte) {
     return err;
 }
 
-int ps2_uart_write_byte_start(uint8_t byte) {
-    struct ps2_uart_data *data = &ps2_uart_data;
+int ps2_uart_write_byte_start(const struct device *dev, uint8_t byte) {
+    struct ps2_uart_data *data = dev->data;
     int err;
 
     // Take semaphore so that when `ps2_uart_write_byte_blocking` attempts
@@ -909,7 +901,7 @@ int ps2_uart_write_byte_start(uint8_t byte) {
         return err;
     }
 
-    err = ps2_uart_set_mode_write();
+    err = ps2_uart_set_mode_write(dev);
     if (err != 0) {
         LOG_ERR("Could not configure driver for write mode: %d", err);
         return err;
@@ -922,12 +914,12 @@ int ps2_uart_write_byte_start(uint8_t byte) {
     data->cur_write_pos = PS2_UART_POS_START;
 
     // Inhibit the line by setting clock low and data high for 100us
-    ps2_uart_set_scl(0);
-    ps2_uart_set_sda(1);
+    ps2_uart_set_scl(dev, 0);
+    ps2_uart_set_sda(dev, 1);
     k_busy_wait(PS2_UART_TIMING_SCL_INHIBITION);
 
     // Set data to value of start bit
-    ps2_uart_set_sda(0);
+    ps2_uart_set_sda(dev, 0);
     k_busy_wait(PS2_UART_TIMING_SCL_INHIBITION);
 
     // The start bit was sent by setting sda to low
@@ -937,13 +929,13 @@ int ps2_uart_write_byte_start(uint8_t byte) {
 
     // Release the clock line and configure it as input
     // This let's the device take control of the clock again
-    ps2_uart_set_scl(1);
-    ps2_uart_configure_pin_scl_input();
+    ps2_uart_set_scl(dev, 1);
+    ps2_uart_configure_pin_scl_input(dev);
 
     // We need to wait for the first SCL clock
     // Execution continues once it arrives in
     // `ps2_uart_write_scl_interrupt_handler`
-    ps2_uart_set_scl_callback_enabled(true);
+    ps2_uart_set_scl_callback_enabled(dev, true);
 
     // And if the PS/2 device doesn't start the clock, we want to
     // handle that error...
@@ -956,13 +948,20 @@ int ps2_uart_write_byte_start(uint8_t byte) {
 }
 
 void ps2_uart_write_scl_timeout(struct k_work *item) {
+
+    struct k_work_delayable *work_delayable = (struct k_work_delayable *)item;
+    struct ps2_uart_data *data = CONTAINER_OF(work_delayable,
+                                              struct ps2_uart_data,
+                                              write_scl_timout);
+    const struct device *dev = data->dev;
+
     // Once we start a transmission we expect the device to
     // to send a new clock/interrupt within
     // PS2_UART_TIMEOUT_WRITE_SCL_START us.
     // If we don't receive the next interrupt within that timeframe,
     // we abort the write.
 
-    ps2_uart_write_finish(false, "scl timeout");
+    ps2_uart_write_finish(dev, false, "scl timeout");
 }
 
 // The nrf52 is too slow to process all SCL interrupts, so we
@@ -980,10 +979,10 @@ void ps2_uart_write_scl_timeout(struct k_work *item) {
 // So, we use a GPIO interrupt to wait for the first clock cycle and
 // then use delays to send the actual data at the same rate as the
 // UART baud rate.
-void ps2_uart_write_scl_interrupt_handler_blocking(const struct device *dev,
-                                                   struct gpio_callback *cb, uint32_t pins) {
-    struct ps2_uart_data *data = &ps2_uart_data;
-
+void ps2_uart_write_scl_interrupt_handler_blocking(struct ps2_uart_data *data,
+                                                   const struct device *gpio_dev,
+                                                   struct gpio_callback *cb, 
+                                                   uint32_t pins) {
     LOG_INF("Inside ps2_uart_write_scl_interrupt_handler_blocking");
 
     // Cancel the SCL timeout
@@ -991,7 +990,7 @@ void ps2_uart_write_scl_interrupt_handler_blocking(const struct device *dev,
 
     // Disable the SCL interrupt again.
     // From here we will just use time delays.
-    ps2_uart_set_scl_callback_enabled(false);
+    ps2_uart_set_scl_callback_enabled(data->dev, false);
 
     for (int i = PS2_UART_POS_DATA_FIRST; i <= PS2_UART_POS_STOP; i++) {
 
@@ -1000,20 +999,20 @@ void ps2_uart_write_scl_interrupt_handler_blocking(const struct device *dev,
             int data_pos = i - PS2_UART_POS_DATA_FIRST;
             bool data_bit = PS2_UART_GET_BIT(data->cur_write_byte, data_pos);
 
-            ps2_uart_set_sda(data_bit);
+            ps2_uart_set_sda(data->dev, data_bit);
         } else if (i == PS2_UART_POS_PARITY) {
 
             bool byte_parity = ps2_uart_get_byte_parity(data->cur_write_byte);
 
-            ps2_uart_set_sda(byte_parity);
+            ps2_uart_set_sda(data->dev, byte_parity);
         } else if (i == PS2_UART_POS_STOP) {
 
-            ps2_uart_set_sda(1);
+            ps2_uart_set_sda(data->dev, 1);
 
             // Give control over data pin back to device after sending
             // the stop bit so that we can receive the ack bit from the
             // device
-            ps2_uart_configure_pin_sda_input();
+            ps2_uart_configure_pin_sda_input(data->dev);
         } else {
             LOG_ERR("UART unknown TX bit number: %d", i);
         }
@@ -1023,21 +1022,21 @@ void ps2_uart_write_scl_interrupt_handler_blocking(const struct device *dev,
     }
 
     // Check Ack
-    int ack_val = ps2_uart_get_sda();
+    int ack_val = ps2_uart_get_sda(data->dev);
 
     if (ack_val == 0) {
-        ps2_uart_write_finish(true, "successful ack");
+        ps2_uart_write_finish(data->dev, true, "successful ack");
     } else {
         // TODO: Properly handle write ack errors
         LOG_WRN("Ack bit was invalid for write of 0x%x", data->cur_write_byte);
-        ps2_uart_write_finish(true, "failed ack");
+        ps2_uart_write_finish(data->dev, true, "failed ack");
     }
 }
 
-void ps2_uart_write_scl_interrupt_handler_async(const struct device *dev, struct gpio_callback *cb,
+void ps2_uart_write_scl_interrupt_handler_async(struct ps2_uart_data *data,
+                                                const struct device *gpio_dev,
+                                                struct gpio_callback *cb,
                                                 uint32_t pins) {
-    struct ps2_uart_data *data = &ps2_uart_data;
-
     k_work_cancel_delayable(&data->write_scl_timout);
 
     if (data->cur_write_pos == PS2_UART_POS_START) {
@@ -1050,30 +1049,30 @@ void ps2_uart_write_scl_interrupt_handler_async(const struct device *dev, struct
         int data_pos = data->cur_write_pos - PS2_UART_POS_DATA_FIRST;
         bool data_bit = PS2_UART_GET_BIT(data->cur_write_byte, data_pos);
 
-        ps2_uart_set_sda(data_bit);
+        ps2_uart_set_sda(data->dev, data_bit);
     } else if (data->cur_write_pos == PS2_UART_POS_PARITY) {
 
         bool byte_parity = ps2_uart_get_byte_parity(data->cur_write_byte);
 
-        ps2_uart_set_sda(byte_parity);
+        ps2_uart_set_sda(data->dev, byte_parity);
     } else if (data->cur_write_pos == PS2_UART_POS_STOP) {
 
-        ps2_uart_set_sda(1);
+        ps2_uart_set_sda(data->dev, 1);
 
         // Give control over data pin back to device after sending
         // the stop bit so that we can receive the ack bit from the
         // device
-        ps2_uart_configure_pin_sda_input();
+        ps2_uart_configure_pin_sda_input(data->dev);
     } else if (data->cur_write_pos == PS2_UART_POS_ACK) {
 
-        int ack_val = ps2_uart_get_sda();
+        int ack_val = ps2_uart_get_sda(data->dev);
 
         if (ack_val == 0) {
-            ps2_uart_write_finish(true, "successful ack");
+            ps2_uart_write_finish(data->dev, true, "successful ack");
         } else {
             // TODO: Properly handle write ack errors
             LOG_WRN("Ack bit was invalid for write of 0x%x", data->cur_write_byte);
-            ps2_uart_write_finish(true, "failed ack");
+            ps2_uart_write_finish(data->dev, true, "failed ack");
         }
     } else {
         LOG_ERR("UART unknown TX bit number: %d", data->cur_write_pos);
@@ -1087,8 +1086,8 @@ void ps2_uart_write_scl_interrupt_handler_async(const struct device *dev, struct
     data->cur_write_pos += 1;
 }
 
-void ps2_uart_write_finish(bool successful, char *descr) {
-    struct ps2_uart_data *data = &ps2_uart_data;
+void ps2_uart_write_finish(const struct device *dev, bool successful, char *descr) {
+    struct ps2_uart_data *data = dev->data;
     int err;
 
     k_work_cancel_delayable(&data->write_scl_timout);
@@ -1102,7 +1101,7 @@ void ps2_uart_write_finish(bool successful, char *descr) {
         data->cur_write_status = PS2_UART_WRITE_STATUS_FAILURE;
     }
 
-    err = ps2_uart_set_mode_read();
+    err = ps2_uart_set_mode_read(dev);
     if (err != 0) {
         LOG_ERR("Could not configure driver for read mode: %d", err);
         return;
@@ -1164,7 +1163,7 @@ static int ps2_uart_configure(const struct device *dev, ps2_callback_t callback_
 
 int ps2_uart_read(const struct device *dev, uint8_t *value) {
     uint8_t queue_byte;
-    int err = ps2_uart_data_queue_get_next(&queue_byte, PS2_UART_TIMEOUT_READ);
+    int err = ps2_uart_data_queue_get_next(dev, &queue_byte, PS2_UART_TIMEOUT_READ);
     if (err) { // Timeout due to no data to read in data queue
         // LOG_DBG("ps2_uart_read: Fifo timed out...");
 
@@ -1178,7 +1177,7 @@ int ps2_uart_read(const struct device *dev, uint8_t *value) {
 }
 
 static int ps2_uart_write(const struct device *dev, uint8_t value) {
-    int ret = ps2_uart_write_byte(value);
+    int ret = ps2_uart_write_byte(dev, value);
 
     return ret;
 }
@@ -1188,7 +1187,7 @@ static int ps2_uart_disable_callback(const struct device *dev) {
 
     // Make sure there are no stale items in the data queue
     // from before the callback was disabled.
-    ps2_uart_data_queue_empty();
+    ps2_uart_data_queue_empty(dev);
 
     data->callback_enabled = false;
 
@@ -1203,7 +1202,7 @@ static int ps2_uart_enable_callback(const struct device *dev) {
 
     // LOG_DBG("Enabled PS2 callback.");
 
-    ps2_uart_data_queue_empty();
+    ps2_uart_data_queue_empty(dev);
 
     return 0;
 }
@@ -1219,17 +1218,30 @@ static const struct ps2_driver_api ps2_uart_driver_api = {
 /*
  * PS/2 UART Driver Init
  */
-static int ps2_uart_init_uart(void);
-static int ps2_uart_init_gpio(void);
+static int ps2_uart_init_uart(const struct device *dev);
+static int ps2_uart_init_gpio(const struct device *dev);
 
 static int ps2_uart_init(const struct device *dev) {
     int err;
     struct ps2_uart_data *data = dev->data;
-    struct ps2_uart_config *config = (struct ps2_uart_config *)&ps2_uart_config;
+    const struct ps2_uart_config *config = dev->config;
 
     // Set the ps2 device so we can retrieve it later for
     // the ps2 callback
     data->dev = dev;
+
+    data->callback_byte = 0x0;
+    data->callback_isr = NULL;
+    data->callback_enabled = false;
+    data->cur_write_status = PS2_UART_WRITE_STATUS_INACTIVE;
+    data->cur_write_byte = 0x0;
+    data->cur_write_pos = 0;
+    data->write_awaits_resp = false;
+    data->write_awaits_resp_byte = 0x0;
+
+#if IS_ENABLED(CONFIG_PS2_UART_ENABLE_PS2_RESEND_CALLBACK)
+    data->resend_callback_isr = NULL;
+#endif /* IS_ENABLED(CONFIG_PS2_UART_ENABLE_PS2_RESEND_CALLBACK) */
 
     // Get the P0.08 pin notation of the configured UART pinctrl pin.
     // The UART TX pin is the second (index 1) of the pins
@@ -1267,19 +1279,19 @@ static int ps2_uart_init(const struct device *dev) {
     // Init semaphore that waits for read after write
     k_sem_init(&data->write_awaits_resp_sem, 0, 1);
 
-    err = ps2_uart_init_uart();
+    err = ps2_uart_init_uart(dev);
     if (err != 0) {
         LOG_ERR("Could not init UART: %d", err);
         return err;
     }
 
-    err = ps2_uart_init_gpio();
+    err = ps2_uart_init_gpio(dev);
     if (err != 0) {
         LOG_ERR("Could not init GPIO: %d", err);
         return err;
     }
 
-    err = ps2_uart_set_mode_read();
+    err = ps2_uart_set_mode_read(dev);
     if (err != 0) {
         LOG_ERR("Could not initialize in UART mode read: %d", err);
         return err;
@@ -1288,9 +1300,9 @@ static int ps2_uart_init(const struct device *dev) {
     return 0;
 }
 
-static int ps2_uart_init_uart(void) {
-    struct ps2_uart_data *data = &ps2_uart_data;
-    struct ps2_uart_config *config = (struct ps2_uart_config *)&ps2_uart_config;
+static int ps2_uart_init_uart(const struct device *dev) {
+    struct ps2_uart_data *data = dev->data;
+    const struct ps2_uart_config *config = dev->config;
     int err;
 
     if (!device_is_ready(config->uart_dev)) {
@@ -1330,17 +1342,17 @@ static int ps2_uart_init_uart(void) {
     return 0;
 }
 
-static int ps2_uart_init_gpio(void) {
-    struct ps2_uart_data *data = &ps2_uart_data;
-    struct ps2_uart_config *config = (struct ps2_uart_config *)&ps2_uart_config;
+static int ps2_uart_init_gpio(const struct device *dev) {
+    struct ps2_uart_data *data = dev->data;
+    const struct ps2_uart_config *config = dev->config;
     int err;
 
     // Interrupt for clock line
 #if IS_ENABLED(CONFIG_PS2_UART_WRITE_MODE_BLOCKING)
-    gpio_init_callback(&data->scl_cb_data, ps2_uart_write_scl_interrupt_handler_blocking,
+    gpio_init_callback(&data->scl_cb_data, data->scl_rupt_blocking,
                        BIT(config->scl_gpio.pin));
-#else
-    gpio_init_callback(&data->scl_cb_data, ps2_uart_write_scl_interrupt_handler_async,
+#else /* IS_ENABLED(CONFIG_PS2_UART_WRITE_MODE_BLOCKING) */
+    gpio_init_callback(&data->scl_cb_data, data->scl_rupt_async,
                        BIT(config->scl_gpio.pin));
 #endif /* IS_ENABLED(CONFIG_PS2_UART_WRITE_MODE_BLOCKING) */
 
@@ -1352,10 +1364,53 @@ static int ps2_uart_init_gpio(void) {
     }
 
     LOG_INF("Disabling callback...");
-    ps2_uart_set_scl_callback_enabled(false);
+    ps2_uart_set_scl_callback_enabled(dev, false);
 
     return err;
 }
 
-DEVICE_DT_INST_DEFINE(0, &ps2_uart_init, NULL, &ps2_uart_data, &ps2_uart_config, POST_KERNEL, 80,
-                      &ps2_uart_driver_api);
+
+// Define wrapper function declaration for write_scl_interrupt_handler_*
+// will assign to ps2_uart_data in below
+#define PS2_UART_SCL_INTERRUPT_DEFINE(n)                                             \
+    void ps2_uart_write_scl_interrupt_handler_blocking_##n(                          \
+        const struct device *gpio_dev, struct gpio_callback *cb, uint32_t pins);     \
+    void ps2_uart_write_scl_interrupt_handler_async_##n(                             \
+        const struct device *gpio_dev, struct gpio_callback *cb, uint32_t pins);
+
+DT_INST_FOREACH_STATUS_OKAY(PS2_UART_SCL_INTERRUPT_DEFINE)
+
+
+#define PS2_UART_DEFINE(n)                                                           \
+    static struct ps2_uart_data data##n = {                                          \
+        .scl_rupt_blocking = &ps2_uart_write_scl_interrupt_handler_blocking_##n,     \
+        .scl_rupt_async = &ps2_uart_write_scl_interrupt_handler_async_##n,           \
+    };                                                                               \
+    static const struct ps2_uart_config config##n = {                                \
+        .uart_dev = DEVICE_DT_GET(DT_INST_BUS(n)),                                   \
+        .scl_gpio = GPIO_DT_SPEC_INST_GET(n, scl_gpios),                             \
+        .sda_gpio = GPIO_DT_SPEC_INST_GET(n, sda_gpios),                             \
+        .pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_INST_BUS(n)),                           \
+        .scl_gpio_port_num = DT_PROP(DT_INST_PHANDLE(n, scl_gpios), port),           \
+        .sda_gpio_port_num = DT_PROP(DT_INST_PHANDLE(n, sda_gpios), port),           \
+    };                                                                               \
+    DEVICE_DT_INST_DEFINE(0, &ps2_uart_init, NULL, &data##n, &config##n,             \
+                          POST_KERNEL, 80,                                           \
+                          &ps2_uart_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PS2_UART_DEFINE)
+
+
+// Define wrapper function implementation for write_scl_interrupt_handler_*
+// assigned to ps2_uart_data on above
+#define PS2_UART_SCL_INTERRUPT_IMPL_DEFINE(n)                                        \
+    void ps2_uart_write_scl_interrupt_handler_blocking_##n(                          \
+        const struct device *gpio_dev, struct gpio_callback *cb, uint32_t pins) {    \
+        ps2_uart_write_scl_interrupt_handler_blocking(&data##n, gpio_dev, cb, pins); \
+    }                                                                                \
+    void ps2_uart_write_scl_interrupt_handler_async_##n(                             \
+        const struct device *gpio_dev, struct gpio_callback *cb, uint32_t pins) {    \
+        ps2_uart_write_scl_interrupt_handler_async(&data##n, gpio_dev, cb, pins);    \
+    }
+
+DT_INST_FOREACH_STATUS_OKAY(PS2_UART_SCL_INTERRUPT_IMPL_DEFINE)

--- a/src/mouse/input_listener_ps2.c
+++ b/src/mouse/input_listener_ps2.c
@@ -18,7 +18,11 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/endpoints.h>
 #include <zmk/keymap.h>
 #include <zmk/mouse/types.h>
-#include <zmk/mouse/hid.h>
+#include <zmk/hid.h>
+
+#ifndef ZMK_MOUSE_HID_NUM_BUTTONS
+#define ZMK_MOUSE_HID_NUM_BUTTONS 0x05
+#endif
 
 #define ONE_IF_DEV_OK(n)                                                                           \
     COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_PHANDLE(n, device), okay), (1 +), (0 +))


### PR DESCRIPTION
Get pass west validation with `CONFIG_ZMK_INPUT_MOUSE_PS2=y`