### PR TITLE
fix build for zephyr 4.1

### DIFF
--- a/src/drivers/input/input_mouse_ps2.c
+++ b/src/drivers/input/input_mouse_ps2.c
@@ -191,7 +191,7 @@ struct zmk_mouse_ps2_data {
     const struct device *dev;
     struct gpio_dt_spec rst_gpio; /* GPIO used for Power-On-Reset line */
 
-    K_THREAD_STACK_MEMBER(thread_stack, MOUSE_PS2_THREAD_STACK_SIZE);
+    K_KERNEL_STACK_MEMBER(thread_stack, MOUSE_PS2_THREAD_STACK_SIZE);
     struct k_thread thread;
 
     zmk_mouse_ps2_packet_mode packet_mode;


### PR DESCRIPTION
https://docs.zephyrproject.org/latest/releases/release-notes-4.0.html

Macro K_THREAD_STACK_MEMBER, deprecated since v3.5.0, has been removed. Use K_KERNEL_STACK_MEMBER instead.